### PR TITLE
PP-28-Cancel-a-reservation done

### DIFF
--- a/backend/src/main/java/tqs/plugpoint/backend/controllers/ReservationController.java
+++ b/backend/src/main/java/tqs/plugpoint/backend/controllers/ReservationController.java
@@ -1,12 +1,21 @@
 package tqs.plugpoint.backend.controllers;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
 import tqs.plugpoint.backend.entities.Reservation;
 import tqs.plugpoint.backend.services.ReservationService;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/reservations")
@@ -45,13 +54,21 @@ public class ReservationController {
     @PatchMapping("/{id}/status")
     public ResponseEntity<Reservation> updateStatus(
             @PathVariable Long id,
-            @RequestParam Reservation.Status status) {
-        return ResponseEntity.ok(reservationService.updateReservationStatus(id, status));
+            @RequestParam Reservation.Status status,
+            @RequestParam Long userId) {
+        return ResponseEntity.ok(reservationService.updateReservationStatus(id, status, userId));
     }
+
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         reservationService.deleteReservation(id);
         return ResponseEntity.noContent().build();
     }
+    @PostMapping("/{id}/cancel")
+    public ResponseEntity<Reservation> cancelReservation(@PathVariable Long id, @RequestParam Long userId) {
+        Reservation cancelled = reservationService.updateReservationStatus(id, Reservation.Status.CANCELLED, userId);
+        return ResponseEntity.ok(cancelled);
+}
+
 }

--- a/backend/src/main/java/tqs/plugpoint/backend/services/ReservationService.java
+++ b/backend/src/main/java/tqs/plugpoint/backend/services/ReservationService.java
@@ -1,13 +1,14 @@
 package tqs.plugpoint.backend.services;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import tqs.plugpoint.backend.entities.Reservation;
-import tqs.plugpoint.backend.repositories.ReservationRepository;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import tqs.plugpoint.backend.entities.Reservation;
+import tqs.plugpoint.backend.repositories.ReservationRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -41,12 +42,20 @@ public class ReservationService {
         reservationRepository.deleteById(id);
     }
 
-    public Reservation updateReservationStatus(Long id, Reservation.Status status) {
+    public Reservation updateReservationStatus(Long id, Reservation.Status status, Long userId) {
         Optional<Reservation> optional = reservationRepository.findById(id);
-        if (optional.isEmpty())
+        if (optional.isEmpty()) {
             throw new RuntimeException("Reservation not found");
-        Reservation r = optional.get();
-        r.setStatus(status);
-        return reservationRepository.save(r);
+        }
+        Reservation reservation = optional.get();
+
+        // Verifica se a reserva pertence ao userId informado
+        if (!reservation.getUserId().equals(userId)) {
+            throw new RuntimeException("Unauthorized: this reservation does not belong to the user");
+        }
+
+        reservation.setStatus(status);
+        return reservationRepository.save(reservation);
     }
+
 }

--- a/backend/src/test/java/tqs/plugpoint/backend/controllers/ReservationControllerTest.java
+++ b/backend/src/test/java/tqs/plugpoint/backend/controllers/ReservationControllerTest.java
@@ -1,7 +1,6 @@
 package tqs.plugpoint.backend.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -18,7 +17,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -93,13 +93,30 @@ class ReservationControllerTest {
         Reservation reservation = sampleReservation();
         reservation.setStatus(Status.CONFIRMED);
 
-        Mockito.when(reservationService.updateReservationStatus(1L, Status.CONFIRMED))
+        // Ajustar a chamada para incluir userId (igual ao mockReservation)
+        Mockito.when(reservationService.updateReservationStatus(eq(1L), eq(Status.CONFIRMED), eq(5L)))
                 .thenReturn(reservation);
 
         mockMvc.perform(patch("/api/reservations/1/status")
-                .param("status", "CONFIRMED"))
+                .param("status", "CONFIRMED")
+                .param("userId", "5"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("CONFIRMED"));
+    }
+
+    @Test
+    void testCancelReservation() throws Exception {
+        Reservation reservation = sampleReservation();
+        reservation.setStatus(Status.CANCELLED);
+
+        // Mock do cancelamento
+        Mockito.when(reservationService.updateReservationStatus(eq(1L), eq(Status.CANCELLED), eq(5L)))
+                .thenReturn(reservation);
+
+        mockMvc.perform(post("/api/reservations/1/cancel")
+                .param("userId", "5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CANCELLED"));
     }
 
     @Test

--- a/frontend/src/MyReservations.jsx
+++ b/frontend/src/MyReservations.jsx
@@ -45,14 +45,15 @@ function MyReservations() {
 
   const handleCancel = async (reservationId) => {
     try {
-      await fetch(`http://localhost:8080/api/reservations/${reservationId}`, {
-        method: 'DELETE',
+      await fetch(`http://localhost:8080/api/reservations/${reservationId}/cancel?userId=${userId}`, {
+        method: 'POST',
       });
-      setReservations(prev => prev.filter(r => r.id !== reservationId));
+      setReservations(prev => prev.map(r => r.id === reservationId ? {...r, status: 'CANCELLED'} : r));
     } catch (err) {
       console.error('Error cancelling reservation:', err);
     }
   };
+
 
   const getStatusBadge = (status) => {
     const statusClasses = {


### PR DESCRIPTION
Add cancel reservation endpoint with userId validation. This pull request introduces functionality to allow users to cancel their reservations securely. The following changes were made: added a new endpoint POST /api/reservations/{id}/cancel?userId={userId} in ReservationController for cancelling reservations; updated ReservationService to include user validation in updateReservationStatus method, ensuring only the reservation owner can cancel it; modified updateReservationStatus to handle status changes securely, preserving reservation data with CANCELLED status; updated ReservationControllerTest to include integration tests for the cancel endpoint and validate correct behavior; enhanced ReservationServiceTest with unit tests verifying the status change to CANCELLED. This feature aligns with the user story by providing secure, trackable cancellation of reservations.

To test it:

Build and run the backend with mvn clean install.

Test the new cancel endpoint via Postman, cURL, or frontend: POST http://localhost:8080/api/reservations/{id}/cancel?userId={userId}. Example: curl -X POST "http://localhost:8080/api/reservations/1/cancel?userId=1".

Verify the reservation status is updated to CANCELLED, unauthorized userId returns an error response, and the reservation remains visible.

Confirm frontend integration works with the updated backend.

Run all tests to ensure stability and correctness.