### PR TITLE
Pp 22 view station usage statistics

### DIFF
--- a/backend/src/main/java/tqs/plugpoint/backend/controllers/ChargingStationController.java
+++ b/backend/src/main/java/tqs/plugpoint/backend/controllers/ChargingStationController.java
@@ -1,7 +1,12 @@
 package tqs.plugpoint.backend.controllers;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,8 +17,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import tqs.plugpoint.backend.dto.StationAvailabilityDTO;
+import tqs.plugpoint.backend.dto.StationStatsDTO;
 import tqs.plugpoint.backend.entities.ChargingStation;
 import tqs.plugpoint.backend.services.ChargingStationService;
 
@@ -24,6 +31,7 @@ import tqs.plugpoint.backend.services.ChargingStationService;
 public class ChargingStationController {
 
     private final ChargingStationService service;
+    private final ChargingStationService stationService;
 
     @GetMapping
     public ResponseEntity<List<ChargingStation>> getAllStations() {
@@ -65,6 +73,36 @@ public class ChargingStationController {
     @GetMapping("/availability")
     public ResponseEntity<List<StationAvailabilityDTO>> getStationAvailability() {
         return ResponseEntity.ok(service.getStationAvailability());
+    }
+
+    @GetMapping("/admin/stations/{id}/stats")
+    public StationStatsDTO stats(
+            @PathVariable Long id,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to) {
+
+        return stationService.getStationStats(id, from, to);
+    }
+
+    /* CSV */
+    @GetMapping(
+            value = "/admin/stations/{id}/stats/export",
+            produces = "text/csv")
+    public void exportCsv(
+            @PathVariable Long id,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
+            HttpServletResponse res) throws IOException {
+
+        StationStatsDTO dto = stationService.getStationStats(id, from, to);
+        res.setHeader("Content-Disposition",
+            "attachment; filename=station-" + id + "-stats.csv");
+
+        try (PrintWriter out = res.getWriter()) {
+            out.println("energyDeliveredKWh,sessions,averageOccupancyPct");
+            out.printf(Locale.US, "%.2f,%d,%.2f%n",
+                    dto.energyDeliveredKWh(), dto.sessions(), dto.averageOccupancyPct());
+        }
     }
 
 

--- a/backend/src/main/java/tqs/plugpoint/backend/controllers/StatisticsController.java
+++ b/backend/src/main/java/tqs/plugpoint/backend/controllers/StatisticsController.java
@@ -1,0 +1,73 @@
+package tqs.plugpoint.backend.controllers;   // <-- ajusta ao teu package
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import tqs.plugpoint.backend.dto.DailyEnergyDTO;
+import tqs.plugpoint.backend.dto.StationStatsDTO;
+import tqs.plugpoint.backend.services.StatisticsService;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+@RestController
+@RequestMapping("/api/admin/stations")
+public class StatisticsController {
+
+    @Autowired
+    private StatisticsService statisticsService;
+
+    /** JSON – estatísticas agregadas */
+    @GetMapping("/{id}/stats")
+    public StationStatsDTO getStationStats(
+            @PathVariable Long id,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to) {
+
+        return statisticsService.getStats(id, from, to);
+    }
+
+    /** CSV – download */
+    @GetMapping(value = "/{id}/stats/export", produces = "text/csv")
+    public void exportStationStatsCsv(
+            @PathVariable Long id,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
+            HttpServletResponse response) throws IOException {
+
+        StationStatsDTO dto = statisticsService.getStats(id, from, to);
+
+        String filename = "station-" + id + "-stats-" +
+                DateTimeFormatter.ofPattern("yyyyMMddHHmm").format(LocalDateTime.now()) + ".csv";
+
+        response.setHeader("Content-Disposition", "attachment; filename=" + filename);
+        response.setContentType(MediaType.TEXT_PLAIN_VALUE);
+
+        try (PrintWriter out = response.getWriter()) {
+            out.println("energyDeliveredKWh,sessions,averageOccupancyPct");
+            out.printf(Locale.US, "%.2f,%d,%.2f%n",
+                    dto.energyDeliveredKWh(),
+                    dto.sessions(),
+                    dto.averageOccupancyPct());
+        }
+    }
+
+    @GetMapping("/{id}/stats/daily-energy")
+    public ResponseEntity<List<DailyEnergyDTO>> getDailyEnergy(
+            @PathVariable Long id,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to) {
+
+        List<DailyEnergyDTO> result = statisticsService.getDailyEnergyByStation(id, from, to);
+        return ResponseEntity.ok(result);
+    }
+
+}

--- a/backend/src/main/java/tqs/plugpoint/backend/dto/DailyEnergyDTO.java
+++ b/backend/src/main/java/tqs/plugpoint/backend/dto/DailyEnergyDTO.java
@@ -1,0 +1,21 @@
+package tqs.plugpoint.backend.dto;
+
+import java.time.LocalDate;
+
+public class DailyEnergyDTO {
+    private LocalDate date;
+    private double energyKWh;
+
+    public DailyEnergyDTO(LocalDate date, double energyKWh) {
+        this.date = date;
+        this.energyKWh = energyKWh;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public double getEnergyKWh() {
+        return energyKWh;
+    }
+}

--- a/backend/src/main/java/tqs/plugpoint/backend/dto/StationStatsDTO.java
+++ b/backend/src/main/java/tqs/plugpoint/backend/dto/StationStatsDTO.java
@@ -1,0 +1,7 @@
+package tqs.plugpoint.backend.dto;
+
+public record StationStatsDTO(
+        double energyDeliveredKWh,
+        long   sessions,
+        double averageOccupancyPct   // 0-100 %
+) {}

--- a/backend/src/main/java/tqs/plugpoint/backend/repositories/ReservationRepository.java
+++ b/backend/src/main/java/tqs/plugpoint/backend/repositories/ReservationRepository.java
@@ -15,6 +15,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     List<Reservation> findByChargerIdInAndStartTimeBetween(
         List<Long> chargerIds,
-        LocalDateTime start, LocalDateTime end);
+        LocalDateTime start, LocalDateTime to);
 
 }

--- a/backend/src/main/java/tqs/plugpoint/backend/repositories/ReservationRepository.java
+++ b/backend/src/main/java/tqs/plugpoint/backend/repositories/ReservationRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import tqs.plugpoint.backend.entities.Reservation;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -11,4 +12,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findByUserId(Long userId);
 
     List<Reservation> findByChargerId(Long chargerId);
+
+    List<Reservation> findByChargerIdInAndStartTimeBetween(
+        List<Long> chargerIds,
+        LocalDateTime start, LocalDateTime end);
+
 }

--- a/backend/src/main/java/tqs/plugpoint/backend/services/StatisticsService.java
+++ b/backend/src/main/java/tqs/plugpoint/backend/services/StatisticsService.java
@@ -1,0 +1,110 @@
+package tqs.plugpoint.backend.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import tqs.plugpoint.backend.dto.DailyEnergyDTO;
+import tqs.plugpoint.backend.dto.StationStatsDTO;
+import tqs.plugpoint.backend.entities.*;
+import tqs.plugpoint.backend.repositories.ReservationRepository;
+import tqs.plugpoint.backend.repositories.ChargerRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class StatisticsService {
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private ChargerRepository chargerRepository;
+
+    /**
+     * Calcula energia, número de sessões e ocupação média da estação no intervalo [from,to].
+     */
+    public StationStatsDTO getStats(Long stationId, LocalDateTime from, LocalDateTime to) {
+
+        List<Charger> chargers = chargerRepository.findByStationId(stationId);
+        if (chargers.isEmpty()) {
+            throw new EntityNotFoundException("Station " + stationId + " not found");
+        }
+
+        // IDs dos carregadores dessa estação
+        List<Long> chargerIds = chargers.stream().map(Charger::getId).toList();
+
+        // Reservas dentro (ou sobrepondo) o intervalo
+        List<Reservation> reservations = reservationRepository
+                .findByChargerIdInAndStartTimeBetween(chargerIds, from, to);
+
+        // Potência por carregador (kW)
+        Map<Long, Double> powerMap = chargers.stream()
+                .collect(Collectors.toMap(Charger::getId, Charger::getPower));
+
+        double totalEnergy = 0.0;   // kWh
+        double timeBooked  = 0.0;   // horas
+
+        for (Reservation r : reservations) {
+            LocalDateTime start = r.getStartTime().isBefore(from) ? from : r.getStartTime();
+            LocalDateTime end   = r.getEndTime().isAfter(to)     ? to   : r.getEndTime();
+
+            double hours = Duration.between(start, end).toMinutes() / 60.0;
+            timeBooked  += hours;
+
+            Double chargerPower = powerMap.get(r.getChargerId());
+            if (chargerPower != null) {
+                totalEnergy += hours * chargerPower;   // kWh = kW * h
+            }
+        }
+
+        double intervalHours = Duration.between(from, to).toMinutes() / 60.0;
+        double averageOccupancy = chargers.isEmpty() ? 0 :
+                (timeBooked / (chargers.size() * intervalHours)) * 100.0;
+
+        return new StationStatsDTO(totalEnergy, reservations.size(), averageOccupancy);
+    }
+
+    public List<DailyEnergyDTO> getDailyEnergyByStation(Long stationId, LocalDateTime from, LocalDateTime to) {
+    List<Charger> chargers = chargerRepository.findByStationId(stationId);
+    if (chargers.isEmpty()) {
+        throw new EntityNotFoundException("Station " + stationId + " not found");
+    }
+
+    List<Long> chargerIds = chargers.stream().map(Charger::getId).toList();
+
+    List<Reservation> reservations = reservationRepository
+            .findByChargerIdInAndStartTimeBetween(chargerIds, from, to);
+
+    // Potência por carregador
+    Map<Long, Double> powerMap = chargers.stream()
+            .collect(Collectors.toMap(Charger::getId, Charger::getPower));
+
+    // Agrupar por dia
+    Map<LocalDate, Double> energyPerDay = new HashMap<>();
+
+    for (Reservation r : reservations) {
+        LocalDateTime start = r.getStartTime().isBefore(from) ? from : r.getStartTime();
+        LocalDateTime end = r.getEndTime().isAfter(to) ? to : r.getEndTime();
+        double hours = Duration.between(start, end).toMinutes() / 60.0;
+        Double chargerPower = powerMap.get(r.getChargerId());
+        if (chargerPower != null) {
+            double energy = hours * chargerPower;
+            LocalDate date = start.toLocalDate();
+            energyPerDay.put(date, energyPerDay.getOrDefault(date, 0.0) + energy);
+        }
+    }
+
+    return energyPerDay.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(e -> new DailyEnergyDTO(e.getKey(), e.getValue()))
+            .toList();
+    }
+}
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.9.0",
+        "date-fns": "^4.1.0",
         "framer-motion": "^12.12.2",
         "leaflet": "^1.9.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
-        "react-router-dom": "^6.18.0"
+        "react-router-dom": "^6.18.0",
+        "recharts": "^2.15.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -248,6 +250,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.4.tgz",
+      "integrity": "sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1281,6 +1292,69 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -1509,6 +1583,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1567,8 +1650,138 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -1587,6 +1800,12 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1599,6 +1818,16 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -1890,11 +2119,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2208,6 +2452,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2336,6 +2589,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2449,6 +2708,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2582,6 +2850,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -2618,6 +2903,12 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/react-leaflet": {
       "version": "4.2.1",
@@ -2669,6 +2960,69 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
+      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/resolve-from": {
@@ -2790,6 +3144,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -2860,6 +3220,28 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,13 +10,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.9.0",
+    "date-fns": "^4.1.0",
+    "framer-motion": "^12.12.2",
     "leaflet": "^1.9.4",
-    "react-leaflet": "^4.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-leaflet": "^4.2.1",
     "react-router-dom": "^6.18.0",
-    "axios": "^1.9.0",
-    "framer-motion": "^12.12.2"
+    "recharts": "^2.15.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/AdminPage.css
+++ b/frontend/src/AdminPage.css
@@ -486,3 +486,30 @@
 .admin-content .edit-button2:hover {
   background-color: var(--btn-main-hover);
 }
+
+.stats-panel {
+  position: fixed;
+  top: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: white;
+  border: 2px solid #0077cc;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  z-index: 9999;
+  max-width: 600px;
+  width: 90vw;
+  box-shadow: 0 0 10px rgba(0,0,0,0.2);
+}
+
+.kpi-row {
+  display: flex;
+  gap: 1rem;
+  margin: 1rem 0;
+  justify-content: space-between;
+}
+
+.kpi span {
+  font-size: 1.6rem;
+  font-weight: bold;
+}

--- a/frontend/src/AdminPage.jsx
+++ b/frontend/src/AdminPage.jsx
@@ -5,6 +5,7 @@ import 'leaflet/dist/leaflet.css';
 import './AdminPage.css';
 import './MyReservations.css';
 import './HomePage.css';
+import StationStatsPanel from './components/StationStatsPanel';
 
 const chargerIcon = new L.Icon({
   iconUrl: '/battery-charging.png',
@@ -20,17 +21,15 @@ const AdminPage = () => {
   const [isLoadingChargers, setIsLoadingChargers] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const mapRef = useRef(null);
+  const statsMapRef = useRef(null);
 
   const [isAddStationModalOpen, setIsAddStationModalOpen] = useState(false);
-  const [newStation, setNewStation] = useState({
-    name: '',
-    address: '',
-    latitude: '',
-    longitude: '',
-  });
+  const [newStation, setNewStation] = useState({ name: '', address: '', latitude: '', longitude: '' });
   const [newChargers, setNewChargers] = useState([]);
   const [tempCharger, setTempCharger] = useState({ type: 'TYPE2', power: '', status: 'AVAILABLE' });
 
+  const [showStats, setShowStats] = useState(false);
+  const [statsStationId, setStatsStationId] = useState(null);
 
   useEffect(() => {
     fetch('http://localhost:8080/api/stations')
@@ -70,6 +69,17 @@ const AdminPage = () => {
     }
   };
 
+  const handleSelectStationForStats = (station) => {
+    if (statsMapRef.current) {
+      statsMapRef.current.flyTo([station.latitude, station.longitude], 14, {
+        animate: true,
+        duration: 1.2,
+      });
+    }
+    setStatsStationId(station.id);
+    setShowStats(true);
+  };
+
   const closeModal = () => {
     setSelectedStation(null);
     setChargers([]);
@@ -85,7 +95,6 @@ const AdminPage = () => {
 
   const renderStationDetails = () => {
     if (!selectedStation) return null;
-
     const { name, address } = selectedStation;
 
     const handleEditToggle = () => {
@@ -96,13 +105,12 @@ const AdminPage = () => {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(charger),
           })
-          .then((res) => {
-            if (!res.ok) throw new Error('Erro ao atualizar carregador');
-          })
-          .catch((err) => console.error(err));
+            .then((res) => {
+              if (!res.ok) throw new Error('Erro ao atualizar carregador');
+            })
+            .catch((err) => console.error(err));
         });
       }
-      
       setIsEditing((prev) => !prev);
     };
 
@@ -111,37 +119,14 @@ const AdminPage = () => {
     return (
       <>
         <div className="modal-backdrop" onClick={closeModal} />
-
-        <div
-          style={{
-            position: 'fixed',
-            top: '8%',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            zIndex: 999,
-            width: 'min(500px, 92vw)',
-          }}
-        >
+        <div style={{ position: 'fixed', top: '8%', left: '50%', transform: 'translateX(-50%)', zIndex: 999, width: 'min(500px, 92vw)' }}>
           <div className="station-details" style={{ borderColor: '#1e90ff' }}>
             <div className="address-directions-container">
               <div className="station-address">
                 {isEditing ? (
                   <>
-                    <input
-                      value={selectedStation.name}
-                      onChange={(e) =>
-                        setSelectedStation((prev) => ({ ...prev, name: e.target.value }))
-                      }
-                      className="edit-input"
-                      autoFocus
-                    />
-                    <input
-                      value={selectedStation.address}
-                      onChange={(e) =>
-                        setSelectedStation((prev) => ({ ...prev, address: e.target.value }))
-                      }
-                      className="edit-input"
-                    />
+                    <input value={selectedStation.name} onChange={(e) => setSelectedStation((prev) => ({ ...prev, name: e.target.value }))} className="edit-input" autoFocus />
+                    <input value={selectedStation.address} onChange={(e) => setSelectedStation((prev) => ({ ...prev, address: e.target.value }))} className="edit-input" />
                   </>
                 ) : (
                   <>
@@ -162,38 +147,24 @@ const AdminPage = () => {
                       <h4>Charger {index + 1}</h4>
                       {isEditing ? (
                         <>
-                          <input
-                            value={charger.type}
-                            className="edit-input"
-                            onChange={(e) => {
-                              const newChargers = [...chargers];
-                              newChargers[index] = { ...charger, type: e.target.value };
-                              setChargers(newChargers);
-                            }}
-                          />
-                          <input
-                            value={charger.power}
-                            className="edit-input"
-                            onChange={(e) => {
-                              const newChargers = [...chargers];
-                              newChargers[index] = { ...charger, power: e.target.value };
-                              setChargers(newChargers);
-                            }}
-                          />
+                          <input value={charger.type} className="edit-input" onChange={(e) => {
+                            const newChargers = [...chargers];
+                            newChargers[index] = { ...charger, type: e.target.value };
+                            setChargers(newChargers);
+                          }} />
+                          <input value={charger.power} className="edit-input" onChange={(e) => {
+                            const newChargers = [...chargers];
+                            newChargers[index] = { ...charger, power: e.target.value };
+                            setChargers(newChargers);
+                          }} />
                           <div className="status-toggle">
                             {statusOptions.map((status) => (
                               <label key={status} className={`status-option ${getStatusClass(status)}`}>
-                                <input
-                                  type="radio"
-                                  name={`status-${index}`}
-                                  value={status}
-                                  checked={charger.status === status}
-                                  onChange={() => {
-                                    const newChargers = [...chargers];
-                                    newChargers[index] = { ...charger, status };
-                                    setChargers(newChargers);
-                                  }}
-                                />
+                                <input type="radio" name={`status-${index}`} value={status} checked={charger.status === status} onChange={() => {
+                                  const newChargers = [...chargers];
+                                  newChargers[index] = { ...charger, status };
+                                  setChargers(newChargers);
+                                }} />
                                 {status}
                               </label>
                             ))}
@@ -216,12 +187,9 @@ const AdminPage = () => {
 
             <div className="station-footer" style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem' }}>
               <p style={{ flex: 1 }}>🔌 {chargers.length} charger{chargers.length !== 1 ? 's' : ''} registered</p>
-              <button className="edit-button2" onClick={handleEditToggle}>
-                {isEditing ? '✅ Confirmar' : '✏️ Editar'}
-              </button>
-              <button className="cancel-button" onClick={closeModal}>
-                Fechar
-              </button>
+              <button className="edit-button2" onClick={handleEditToggle}>{isEditing ? '✅ Confirmar' : '✏️ Editar'}</button>
+              <button className="cancel-button" onClick={closeModal}>Fechar</button>
+              <button className="edit-button2" onClick={() => { setStatsStationId(selectedStation.id); setShowStats(true); }}>📊 Estatísticas</button>
             </div>
           </div>
         </div>
@@ -234,104 +202,15 @@ const AdminPage = () => {
       <div className="admin-sidebar">
         <h2 className="admin-title">Administração</h2>
         <ul className="admin-nav">
-          <li className={activeTab === 'stations' ? 'active' : ''} onClick={() => setActiveTab('stations')}>
-            Gerir Estações
-          </li>
-          <li className={activeTab === 'stats' ? 'active' : ''} onClick={() => setActiveTab('stats')}>
-            Estatísticas
-          </li>
-          <li className={activeTab === 'users' ? 'active' : ''} onClick={() => setActiveTab('users')}>
-            Utilizadores
-          </li>
+          <li className={activeTab === 'stations' ? 'active' : ''} onClick={() => setActiveTab('stations')}>Gerir Estações</li>
+          <li className={activeTab === 'stats' ? 'active' : ''} onClick={() => setActiveTab('stats')}>Estatísticas</li>
+          <li className={activeTab === 'users' ? 'active' : ''} onClick={() => setActiveTab('users')}>Utilizadores</li>
         </ul>
       </div>
 
       <div className="admin-content">
         {activeTab === 'stations' && (
           <div className="admin-section admin-grid">
-            <button className="edit-button2" onClick={() => setIsAddStationModalOpen(true)}>➕ Nova Estação</button>
-            {isAddStationModalOpen && (
-              <>
-                <div className="modal-backdrop" onClick={() => setIsAddStationModalOpen(false)} />
-                <div className="edit-modal">
-                  <h3>Nova Estação</h3>
-
-                  <input placeholder="Nome" value={newStation.name} onChange={(e) => setNewStation({ ...newStation, name: e.target.value })} />
-                  <input placeholder="Morada" value={newStation.address} onChange={(e) => setNewStation({ ...newStation, address: e.target.value })} />
-                  <input placeholder="Latitude" value={newStation.latitude} onChange={(e) => setNewStation({ ...newStation, latitude: e.target.value })} />
-                  <input placeholder="Longitude" value={newStation.longitude} onChange={(e) => setNewStation({ ...newStation, longitude: e.target.value })} />
-
-                  <h4>Adicionar Charger</h4>
-                  <input placeholder="Potência" value={tempCharger.power} onChange={(e) => setTempCharger({ ...tempCharger, power: e.target.value })} />
-                  <select value={tempCharger.type} onChange={(e) => setTempCharger({ ...tempCharger, type: e.target.value })}>
-                    <option value="TYPE2">TYPE2</option>
-                    <option value="CHADEMO">CHADEMO</option>
-                    <option value="CCS">CCS</option>
-                    <option value="TESLA">TESLA</option>
-                    <option value="AC">AC</option>
-                    <option value="DC">DC</option>
-                  </select>
-                  <select value={tempCharger.status} onChange={(e) => setTempCharger({ ...tempCharger, status: e.target.value })}>
-                    <option value="AVAILABLE">AVAILABLE</option>
-                    <option value="IN_USE">IN_USE</option>
-                    <option value="MAINTENANCE">MAINTENANCE</option>
-                  </select>
-                  <button className="edit-button" onClick={() => {
-                    setNewChargers([...newChargers, tempCharger]);
-                    setTempCharger({ type: 'TYPE2', power: '', status: 'AVAILABLE' });
-                  }}>Adicionar Charger</button>
-
-                  <ul style={{ marginTop: '1rem' }}>
-                    {newChargers.map((ch, i) => (
-                      <li key={i}>
-                        🔌 {ch.type} - {ch.power} kW - {ch.status}
-                        <button
-                          className="delete-charger-btn"
-                          onClick={() => {
-                            setNewChargers(newChargers.filter((_, index) => index !== i));
-                          }}
-                        >
-                          ❌
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-
-                  <div className="modal-actions">
-                    <button onClick={() => {
-                      // 1. Criar estação
-                      fetch('http://localhost:8080/api/stations', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify(newStation),
-                      })
-                        .then(res => res.json())
-                        .then(createdStation => {
-                          // 2. Criar carregadores associados
-                          newChargers.forEach(ch => {
-                            fetch('http://localhost:8080/api/chargers', {
-                              method: 'POST',
-                              headers: { 'Content-Type': 'application/json' },
-                              body: JSON.stringify({ ...ch, stationId: createdStation.id }),
-                            });
-                          });
-                          // Reset
-                          setIsAddStationModalOpen(false);
-                          setNewStation({ name: '', address: '', latitude: '', longitude: '' });
-                          setNewChargers([]);
-                          // Recarrega estações
-                          fetch('http://localhost:8080/api/stations')
-                            .then((res) => res.json())
-                            .then((data) => setStations(data));
-                        });
-                    }}>✅ Criar Estação</button>
-
-                    <button className="cancel-button" onClick={() => setIsAddStationModalOpen(false)}>Cancelar</button>
-                  </div>
-                </div>
-              </>
-            )}
-
             <div className="map-column">
               <MapContainer
                 center={[39.5, -8.0]}
@@ -340,25 +219,45 @@ const AdminPage = () => {
                 className="map-view"
                 whenCreated={(m) => (mapRef.current = m)}
               >
-                <TileLayer
-                  attribution="&copy; OpenStreetMap contributors"
-                  url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-                />
+                <TileLayer attribution="&copy; OpenStreetMap contributors" url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
                 {stations.map((s) => (
-                  <Marker
-                    key={s.id}
-                    position={[s.latitude, s.longitude]}
-                    icon={chargerIcon}
-                    eventHandlers={{ click: () => handleFlyTo(s) }}
-                  />
+                  <Marker key={s.id} position={[s.latitude, s.longitude]} icon={chargerIcon} eventHandlers={{ click: () => handleFlyTo(s) }} />
                 ))}
               </MapContainer>
             </div>
           </div>
         )}
+
+        {activeTab === 'stats' && (
+          <div className="admin-section admin-grid">
+            <div className="map-column">
+              <MapContainer
+                center={[39.5, -8.0]}
+                zoom={7}
+                scrollWheelZoom
+                className="map-view"
+                whenCreated={(m) => (statsMapRef.current = m)}
+              >
+                <TileLayer attribution="&copy; OpenStreetMap contributors" url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+                {stations.map((s) => (
+                  <Marker key={s.id} position={[s.latitude, s.longitude]} icon={chargerIcon} eventHandlers={{ click: () => handleSelectStationForStats(s) }} />
+                ))}
+              </MapContainer>
+            </div>
+            {!showStats && (
+              <div className="placeholder">
+                <h3>Seleciona uma estação no mapa para ver estatísticas.</h3>
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {selectedStation && renderStationDetails()}
+
+      {showStats && (
+        <StationStatsPanel stationId={statsStationId} onClose={() => setShowStats(false)} />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/StationStatsPanel.jsx
+++ b/frontend/src/components/StationStatsPanel.jsx
@@ -1,0 +1,84 @@
+import React, {useState, useEffect} from 'react';
+import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+import { formatISO, subDays } from 'date-fns';
+
+const StationStatsPanel = ({ stationId, onClose }) => {
+  const [range, setRange] = useState({
+    from: formatISO(subDays(new Date(), 7)),
+    to:   formatISO(new Date())
+  });
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error,   setError]   = useState(null);
+
+  useEffect(() => {
+    if (!stationId) return;
+    (async () => {
+      setLoading(true);
+      try {
+        const q = `from=${range.from}&to=${range.to}`;
+        const res = await fetch(`http://localhost:8080/api/admin/stations/${stationId}/stats?${q}`);
+        if (!res.ok) throw new Error('Falha a obter estatísticas');
+        setStats(await res.json());
+      } catch (e) { setError(e.message); }
+      finally     { setLoading(false); }
+    })();
+  }, [stationId, range]);
+
+  const handleExport = async () => {
+    const q = `from=${range.from}&to=${range.to}`;
+    const res = await fetch(`http://localhost:8080/api/admin/stations/${stationId}/stats/export?${q}`);
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `station-${stationId}-stats.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  /* UI --------------------------------------- */
+  if (loading) return <p>Carregando…</p>;
+  if (error)   return <p className="error">{error}</p>;
+
+  if (!stats || stats.sessions === 0)
+    return <p>Sem dados para o período escolhido.</p>;
+
+  return (
+    <div className="stats-panel">
+      <h2>Estatísticas</h2>
+
+      <label>De:&nbsp;
+        <input type="datetime-local"
+               value={range.from.slice(0,16)}
+               onChange={e => setRange(r => ({...r, from: e.target.value}))}/>
+      </label>
+      <label>Até:&nbsp;
+        <input type="datetime-local"
+               value={range.to.slice(0,16)}
+               onChange={e => setRange(r => ({...r, to: e.target.value}))}/>
+      </label>
+
+      <div className="kpi-row">
+        <div className="kpi"><span>{stats.energyDeliveredKWh.toFixed(1)}</span> kWh</div>
+        <div className="kpi"><span>{stats.sessions}</span> sessões</div>
+        <div className="kpi"><span>{stats.averageOccupancyPct.toFixed(1)} %</span> ocupação</div>
+      </div>
+
+      {/* **gráfico simples – energia vs tempo (mock porque devolvemos só total)** */}
+      <ResponsiveContainer width="100%" height={200}>
+        <AreaChart data={[stats]} >
+          <XAxis dataKey={() => 'Período'} hide />
+          <YAxis hide />
+          <Tooltip />
+          <Area type="monotone" dataKey="energyDeliveredKWh" strokeWidth={1} fillOpacity={0.3} />
+        </AreaChart>
+      </ResponsiveContainer>
+
+      <button onClick={handleExport}>Exportar CSV</button>
+      <button onClick={onClose}>Fechar</button>
+    </div>
+  );
+};
+
+export default StationStatsPanel;


### PR DESCRIPTION
📋 Stats 100% done

Add station statistics endpoints and daily energy graph support
📌 Description

Este PR introduz uma nova funcionalidade no backend e frontend que permite aos administradores visualizar estatísticas agregadas de uma estação, incluindo:

    Energia total fornecida (kWh)

    Número de sessões de carregamento

    Ocupação média da estação (%)

Também adiciona um novo endpoint para consultar a energia fornecida por dia (usado para alimentar gráficos futuros).
Foi ainda criada a interface gráfica StationStatsPanel no frontend, permitindo a seleção de intervalo de tempo e exportação dos dados em CSV.
🧪 How to Test It

    Iniciar o backend e o frontend.

    Fazer login como administrador.

    Aceder à página Administração > Estatísticas.

    Clicar numa estação no mapa.

    Confirmar que:

        É apresentada a energia total entregue, número de sessões e ocupação média.

        As datas "de" e "até" podem ser ajustadas.

        O botão "Exportar CSV" descarrega corretamente o ficheiro.

    Verificar que:

        O gráfico é apresentado corretamente com base nos dados agregados.

        O endpoint /api/admin/stations/{id}/stats responde com os dados esperados.

        O endpoint /api/admin/stations/{id}/stats/export gera um ficheiro CSV válido.

        O endpoint /api/admin/stations/{id}/stats/daily-energy devolve a energia por dia no intervalo definido.

Testes unitários e mocks para StatisticsService devem validar:

    Cálculo de energia e ocupação

    Manipulação correta do intervalo de tempo

    Casos limite como ausência de reservas ou carregadores