### PR TITLE
PP-33-view-charging-history-and-co₂-savings

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import MyReservations from './MyReservations';
 import TripPlannerPage from './TripPlannerPage';
 import FavoritesPage from './FavoritesPage';
 import Management from './AdminPage';
+import MyStas from './MyStats';
 
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
           <div className="navbar-links">
             <Link to="/">Home</Link>
             <Link to="/reservations">My Reservations</Link>
+            <Link to="/mystats">My Stats</Link>
             <Link to="/trip-planner">Trip Planner</Link>
             <Link to="/favorites">Favoritos</Link>
             <Link to='/management'>Management</Link>
@@ -27,6 +29,7 @@ function App() {
           <Route path="/home" element={<HomePage />} />
           <Route path="/management" element={<Management />} />
           <Route path="/reservations" element={<MyReservations />} />
+          <Route path="/mystats" element={<MyStas />} />
           <Route path="/trip-planner" element={<TripPlannerPage />} />
           <Route path="/favorites" element={<FavoritesPage />} />
         </Routes>

--- a/frontend/src/MyStats.css
+++ b/frontend/src/MyStats.css
@@ -1,0 +1,199 @@
+:root {
+    /* 🌈 NEON PALETTE */
+    --bg1: #0f1d2e;
+    --bg2: #174a70;
+    --bg3: #1e90ff;
+    --glass: rgba(23, 74, 112, 0.55); /* painel esbatido */
+    --glass-blur: 10px;
+    --card-bg: rgba(255, 255, 255, 0.06);
+    --accent: #1e90ff;
+    --accent-light: #4aa6ff;
+    --danger: #e53e3e;
+    --radius: 12px;
+    --white: #e6f4ff;
+    --shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+  }
+  
+  /* ───────────────────────── BASE LAYOUT ───────────────────────── */
+  .stats-page {
+    min-height: 100vh;
+    width: 100%;
+    background: linear-gradient(135deg, var(--bg1) 0%, var(--bg2) 30%, var(--bg3) 100%);
+    padding: 2rem;
+    color: var(--white);
+    font-family: "Segoe UI", sans-serif;
+    box-sizing: border-box;
+  }
+  
+  .content-wrapper {
+    display: flex;
+    gap: 2rem;
+    width: 100%;
+    max-width: 100%;
+  }
+  
+  /* ── LEFT: CARDS GRID */
+  .cards-column {
+    flex: 3;
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .section-title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    color: #ffffff;
+    margin: 0 0 1.2rem 0;
+    text-shadow: 0 0 10px var(--accent-light);
+  }
+  
+  .no-data {
+    opacity: 0.8;
+    font-size: 1rem;
+    margin-top: 1rem;
+  }
+  
+  /* ✓ GRID DE CARTÕES */
+  .reservation-grid.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 1.5rem;
+    width: 100%;
+  }
+  
+  /* ✨ CARD */
+  .reservation-card {
+    background: var(--card-bg);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    backdrop-filter: blur(var(--glass-blur));
+    padding: 1.25rem 1rem;
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+  }
+  .reservation-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+  }
+  
+  /* VARIANTE PEQUENA */
+  .reservation-card.sm {
+    padding: 1rem;
+  }
+  
+  .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.6rem;
+  }
+  
+  .station-name {
+    font-size: 1rem;
+    font-weight: 600;
+    max-width: 150px;
+    line-height: 1.2;
+  }
+  
+  /* BADGE */
+  .status-badge {
+    padding: 0.15rem 0.6rem;
+    border-radius: var(--radius);
+    font-size: 0.65rem;
+    font-weight: 700;
+    background: var(--accent-light);
+    color: #000;
+    text-shadow: 0 0 6px var(--accent-light);
+  }
+  .status-confirmed {
+    /* mantenha mesma cor de accent-light */
+  }
+  
+  /* SESSÕES DO CARD */
+  .card-section {
+    margin-bottom: 0.4rem;
+    font-size: 0.85rem;
+    line-height: 1.3;
+  }
+  
+  .section-sub {
+    font-weight: 500;
+  }
+  
+  .charger-line,
+  .date-line,
+  .co2-line {
+    display: flex;
+    justify-content: space-between;
+  }
+  
+  /* Ícone de CO₂ (pequeno subtítulo) */
+  .co2-line span:first-child {
+    font-weight: 500;
+  }
+  
+  /* ───────────────────────── RIGHT PANEL ───────────────────────── */
+  .stats-panel {
+    flex: 1;
+    background: var(--glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border: 2px solid var(--accent);
+    border-radius: var(--radius);
+    padding: 1.5rem 1.25rem;
+    box-shadow: var(--shadow);
+    height: fit-content;
+    position: sticky;
+    top: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+  }
+  
+  .panel-title {
+    font-size: 1.4rem;
+    font-weight: 700;
+    margin: 0;
+    text-shadow: 0 0 8px var(--accent-light);
+  }
+  
+  .stats-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+  }
+  
+  .stats-list li {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.95rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+    padding-bottom: 0.4rem;
+  }
+  
+  .stats-list li:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+  
+  .stats-list span:first-child {
+    color: var(--accent-light);
+  }
+  
+  .stats-list span:last-child {
+    font-weight: 700;
+  }
+  
+  /* RESPONSIVE ─ COLAPSAR COLUNAS EM TELA PEQUENA */
+  @media (max-width: 900px) {
+    .content-wrapper {
+      flex-direction: column;
+    }
+    .stats-panel {
+      position: static;
+      width: 100%;
+    }
+  }
+  

--- a/frontend/src/MyStats.jsx
+++ b/frontend/src/MyStats.jsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useState } from 'react';
+import './MyStats.css';
+
+// Fatores aproximados de CO₂ poupado (kg CO₂ por kWh) dependendo do tipo de carregador.
+// Estes valores são meramente indicativos e podem ser ajustados conforme a fonte de energia.
+const CO2_FACTORS = {
+  TYPE2: 0.20,
+  CHADEMO: 0.18,
+  CCS: 0.18,
+  TESLA: 0.17,
+  AC: 0.22,
+  DC: 0.19,
+};
+
+/**
+ * Calcula o CO₂ poupado numa reserva de 1 hora, em kg.
+ *
+ * A fórmula base: CO₂_poupado = (potência_em_kW × horas) × fator_co2.
+ * Como cada reserva é sempre de 1 hora, a componente "horas" é 1.
+ *
+ * @param {string} chargerType — tipo do carregador (enum ChargerType).
+ * @param {number} power — potência do carregador em kW.
+ * @returns {number} valor de CO₂ poupado em kg, arredondado a 2 casas decimais.
+ */
+function calculateCO2Saved(chargerType, power) {
+  const factor = CO2_FACTORS[chargerType] || 0.18; // valor padrão caso o tipo não exista no map
+  const co2Saved = power * factor * 1; // horas = 1
+  return parseFloat(co2Saved.toFixed(2));
+}
+
+export default function MyStats() {
+  const [reservations, setReservations] = useState([]);
+  const [stationInfoMap, setStationInfoMap] = useState({});
+  const [chargerMap, setChargerMap] = useState({});
+  const userId = 1;
+
+  useEffect(() => {
+    const fetchAllReservationDetails = async () => {
+      try {
+        const res = await fetch(`http://localhost:8080/api/reservations/user/${userId}`);
+        const reservationsData = (await res.json()) || [];
+        setReservations(reservationsData);
+
+        const chargerMapTemp = {};
+        const stationMapTemp = {};
+
+        for (const reservation of reservationsData) {
+          // ── Somente reservas CONFIRMED importam para estatísticas
+          if (reservation.status !== 'CONFIRMED') continue;
+
+          const chargerId = reservation.chargerId;
+          if (!chargerMapTemp[chargerId]) {
+            const chargerRes = await fetch(`http://localhost:8080/api/chargers/${chargerId}`);
+            const charger = await chargerRes.json();
+            chargerMapTemp[chargerId] = charger;
+
+            if (charger.stationId && !stationMapTemp[charger.stationId]) {
+              const stationRes = await fetch(`http://localhost:8080/api/stations/${charger.stationId}`);
+              const station = await stationRes.json();
+              stationMapTemp[charger.stationId] = station;
+            }
+          }
+        }
+
+        setChargerMap(chargerMapTemp);
+        setStationInfoMap(stationMapTemp);
+      } catch (err) {
+        console.error('Error fetching stats:', err);
+      }
+    };
+
+    fetchAllReservationDetails();
+  }, []);
+
+  // ───────────────────────── derived data ──────────────────────────
+  const confirmed = reservations.filter((r) => r.status === 'CONFIRMED');
+
+  // Total de potência reservada (kW)
+  const totalPower = confirmed.reduce((sum, r) => {
+    const ch = chargerMap[r.chargerId];
+    return sum + (ch?.power || 0);
+  }, 0);
+
+  // Total de CO₂ poupado (kg), somando cada reserva de 1h
+  const totalCO2 = confirmed.reduce((sum, r) => {
+    const ch = chargerMap[r.chargerId];
+    if (!ch) return sum;
+    return sum + calculateCO2Saved(ch.type, ch.power);
+  }, 0);
+
+  const uniqueStations = new Set(
+    confirmed.map((r) => {
+      const ch = chargerMap[r.chargerId];
+      return ch?.stationId;
+    })
+  ).size;
+
+  // Componente de badge CONFIRMED
+  const ConfirmedBadge = () => (
+    <span className="status-badge status-confirmed">CONFIRMED</span>
+  );
+
+  return (
+    <div className="stats-page">
+      <div className="content-wrapper">
+        {/* ── LEFT: GRID DE CARTÕES */}
+        <div className="cards-column">
+          <h2 className="section-title">🔌 Confirmed Reservations</h2>
+          {confirmed.length === 0 ? (
+            <p className="no-data">No confirmed reservations yet.</p>
+          ) : (
+            <div className="reservation-grid stats-grid">
+              {confirmed.map((res) => {
+                const charger = chargerMap[res.chargerId];
+                const station = charger?.stationId
+                  ? stationInfoMap[charger.stationId]
+                  : null;
+                const start = new Date(res.startTime);
+                const co2Saved = charger
+                  ? calculateCO2Saved(charger.type, charger.power)
+                  : 0;
+
+                return (
+                  <div className="reservation-card sm" key={res.id}>
+                    <div className="card-header">
+                      <h3 className="station-name">
+                        {station?.name || 'Unknown Station'}
+                      </h3>
+                      <ConfirmedBadge />
+                    </div>
+
+                    <div className="card-section">
+                      <h4 className="section-sub">
+                        📍 {station?.address || 'Unknown address'}
+                      </h4>
+                    </div>
+
+                    {charger && (
+                      <div className="card-section charger-line">
+                        <span>{charger.type}</span>
+                        <span>{charger.power} kW</span>
+                      </div>
+                    )}
+
+                    <div className="card-section date-line">
+                      <span>
+                        {start.toLocaleDateString()} —{' '}
+                        {start.toLocaleTimeString([], {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        })}
+                      </span>
+                    </div>
+
+                    <div className="card-section co2-line">
+                      <span>🌿 CO₂ Saved:</span>
+                      <span>{co2Saved} kg</span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* ── RIGHT: PAINEL DE ESTATÍSTICAS */}
+        <aside className="stats-panel">
+          <h3 className="panel-title">📊 Statistics</h3>
+          <ul className="stats-list">
+            <li>
+              <span>Total confirmed</span>
+              <span>{confirmed.length}</span>
+            </li>
+            <li>
+              <span>Unique stations</span>
+              <span>{uniqueStations}</span>
+            </li>
+            <li>
+              <span>Total reserved power</span>
+              <span>{totalPower.toFixed(1)} kW</span>
+            </li>
+            <li>
+              <span>Total CO₂ Saved</span>
+              <span>{totalCO2.toFixed(2)} kg</span>
+            </li>
+          </ul>
+        </aside>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 📋 Pull Request Title
Add station statistics endpoints and frontend visualization

## 📌 Description
Esta pull request introduz a funcionalidade de estatísticas administrativas para estações de carregamento. Foram realizadas as seguintes alterações:
Backend:

    Adicionado o endpoint GET /api/admin/stations/{id}/stats para obter estatísticas agregadas (energia fornecida, sessões e ocupação).

    Adicionado o endpoint GET /api/admin/stations/{id}/stats/export para exportar essas estatísticas em CSV.

    Adicionado o endpoint GET /api/admin/stations/{id}/stats/daily-energy para devolver a energia fornecida por dia (para gráficos).

    Criado o DTO DailyEnergyDTO.

    Atualizado o StatisticsService para calcular corretamente energia total, número de sessões e ocupação média com base em reservas.

Frontend:

    Criado componente StationStatsPanel que permite:

        Visualizar energia fornecida, sessões e ocupação média.

        Alterar o intervalo temporal com datetime-local.

        Visualizar gráfico de energia fornecida.

        Exportar dados agregados em CSV.

    Atualizada a AdminPage para permitir seleção de estação no modo "Estatísticas" e abrir o painel.


## 🧪 How to Test It
Iniciar o backend (Spring Boot) e o frontend (React).

Fazer login como administrador.

Aceder à página Administração > Estatísticas.

Selecionar uma estação no mapa:

    O painel com as estatísticas deverá aparecer.

    Verificar se os valores de energia, sessões e ocupação são exibidos corretamente.

Ajustar as datas com os campos "De" e "Até":

    Confirmar que os dados e o gráfico se atualizam de acordo.

Clicar em Exportar CSV:

    Verificar que o ficheiro descarregado contém os dados corretos.

Confirmar via DevTools que os seguintes endpoints funcionam corretamente:

    GET /api/admin/stations/{id}/stats

    GET /api/admin/stations/{id}/stats/export

    GET /api/admin/stations/{id}/stats/daily-energy
